### PR TITLE
Compile dependency container with declared getter for each service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/composer.lock
+/koharness_bootstrap.php
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+php: [5.3]
+
+before_script:
+  - composer self-update
+  - composer install
+  # Generate the koharness Kohana default application
+  - vendor/bin/koharness
+
+script: vendor/bin/phpspec

--- a/README.md
+++ b/README.md
@@ -143,3 +143,32 @@ You can also create a container by using the programmatic API.
 			->set_shared(TRUE)
 		)
 	);
+
+## Compiling a dependency container
+
+By default, you access dependencies by their service path. If you want, you can compile a container class that exposes
+each service as a typehinted method.
+
+In other words:
+
+```php
+// You get this
+$services->get_swift_mailer()->send($message);
+
+// Instead of this
+$services->get('swift.mailer').send($message);
+```
+
+This provides several benefits:
+
+* IDE autocompletion of available services
+* IDE autocompletion and usage detection of the methods on the services themselves
+* Clear, maintainable, definitions of which implementation of an interface is actually in use for easier debugging
+* Compile-time validation of your service configurations
+
+Compile your dependencies with the provided [compile:dependencies](classes/Task/Compile/Dependencies.php) minion task.
+During the task, the compiler will create every service in your definition list, and fail with an error if any service
+cannot be instantiated.
+
+The recommended use is to place this minion task within your build/deploy task, so that the container is compiled fresh
+for every deployment and fails early if there are any undetected breaking changes in your dependencies.

--- a/classes/Dependency/Compiler.php
+++ b/classes/Dependency/Compiler.php
@@ -17,8 +17,7 @@ class Dependency_Compiler
  * Auto-generated from your services configuration
  * [!!] Changes will be overwritten
  */
-
-class :class_name extends \Dependency_Container {
+class :class_name extends :parent_class_name {
 
 
 PHP;
@@ -103,7 +102,7 @@ PHP;
 		);
 	}
 
-	/**
+    /**
 	 * @param Dependency_Definition $definition
 	 * @return string
 	 */
@@ -124,13 +123,13 @@ PHP;
 		return 'mixed';
 	}
 
-	/**
+    /**
 	 * @return void
 	 */
 	protected function write_class_definition()
 	{
-		$content = strtr(self::CLASS_HEADER, array(':class_name' => $this->class_name));
-		ksort($this->getters);
+        $content = $this->build_class_header();
+        ksort($this->getters);
 		foreach ($this->getters as $getter) {
 			$content .= strtr(self::GETTER_METHOD, $getter);
 		}
@@ -138,7 +137,22 @@ PHP;
 		file_put_contents($this->filename, $content);
 	}
 
-	/**
+    /**
+     * @return string
+     */
+    protected function build_class_header()
+    {
+        $params = array(':class_name' => $this->class_name);
+        if ($this->class_name === 'Dependency_Container') {
+            $params[':parent_class_name'] = '\Kohana_Dependency_Container';
+        } else {
+            $params[':parent_class_name'] = '\Dependency_Container';
+        }
+
+        return strtr(self::CLASS_HEADER, $params);
+    }
+
+    /**
 	 * @throws InvalidArgumentException if any service definitions are not valid
 	 */
 	protected function validate_service_definitions()
@@ -170,7 +184,7 @@ PHP;
 		}
 	}
 
-	/**
+    /**
 	 * @param object $service
 	 * @param string $declared_type
 	 *

--- a/classes/Dependency/Compiler.php
+++ b/classes/Dependency/Compiler.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Compiles dependency definitions to a single dependency container class that provides type hinted methods for each
+ * defined service.
+ *
+ * @copyright  2014 inGenerator Ltd
+ * @licence    BSD
+ * @see        spec\Dependency_CompilerSpec
+ */
+class Dependency_Compiler
+{
+
+	const CLASS_HEADER = <<<'PHP'
+<?php
+/**
+ * Auto-generated from your services configuration
+ * [!!] Changes will be overwritten
+ */
+
+class :class_name extends \Dependency_Container {
+
+
+PHP;
+
+	const GETTER_METHOD = <<<'PHP'
+	/**
+	 * @return :return_type
+	 */
+	public function :method_name() {
+		return $this->get(':service_key');
+	}
+
+
+PHP;
+
+	const CLASS_FOOTER = <<<'PHP'
+}
+
+PHP;
+
+	/**
+	 * @var \Dependency_Definition_List
+	 */
+	protected $definitions;
+
+	/**
+	 * @var array
+	 */
+	protected $getters;
+
+	/**
+	 * @var string
+	 */
+	protected $class_name;
+
+	/**
+	 * @var string
+	 */
+	protected $filename;
+
+	/**
+	 * @param string                     $class_name  the class name to produce
+	 * @param string                     $filename    absolute path where the compiled class should be stored
+	 * @param Dependency_Definition_List $definitions definitions to compile into a service class
+	 *
+	 * @return void
+	 */
+	public function compile($class_name, $filename, \Dependency_Definition_List $definitions = NULL)
+	{
+		$this->definitions = $definitions;
+		$this->class_name = $class_name;
+		$this->filename = $filename;
+
+		$this->build_getters();
+		$this->write_class_definition();
+		$this->validate_service_definitions($class_name, $filename);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function build_getters()
+	{
+		$this->getters = array();
+		foreach ($this->definitions as $name => $definition) {
+			$this->build_getter($name, $definition);
+		}
+	}
+
+	/**
+	 * @param string                $service_name
+	 * @param Dependency_Definition $definition
+	 *
+	 * @return void
+	 */
+	protected function build_getter($service_name, Dependency_Definition $definition)
+	{
+		$this->getters[$service_name] = array(
+			':method_name' => 'get_' . str_replace('.', '_', $service_name),
+			':service_key' => $service_name,
+			':return_type' => $this->find_service_type($definition)
+		);
+	}
+
+	/**
+	 * @param Dependency_Definition $definition
+	 * @return string
+	 */
+	protected function find_service_type(Dependency_Definition $definition)
+	{
+		if ( ! $definition->constructor) {
+			return $definition->class;
+		}
+
+		$reflection = new \ReflectionClass($definition->class);
+		$documentation = $reflection->getMethod($definition->constructor)->getDocComment();
+
+		if (preg_match('/\s+\* @return\s+([^\s]+)/', $documentation, $matches)) {
+			return $matches[1];
+		}
+
+		// Type is not known without actually creating an instance
+		return 'mixed';
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function write_class_definition()
+	{
+		$content = strtr(self::CLASS_HEADER, array(':class_name' => $this->class_name));
+		ksort($this->getters);
+		foreach ($this->getters as $getter) {
+			$content .= strtr(self::GETTER_METHOD, $getter);
+		}
+		$content .= self::CLASS_FOOTER;
+		file_put_contents($this->filename, $content);
+	}
+
+	/**
+	 * @throws InvalidArgumentException if any service definitions are not valid
+	 */
+	protected function validate_service_definitions()
+	{
+		require_once $this->filename;
+		$container = new $this->class_name($this->definitions);
+		$errors = array();
+		foreach ($this->getters as $getter) {
+			try {
+				$service = call_user_func(array($container, $getter[':method_name']));
+				if ( ! $this->is_expected_service_type($service, $getter[':return_type'])) {
+					$errors[] = sprintf(
+						'%s: expected %s, got instance of %s',
+						$getter[':service_key'],
+						$getter[':return_type'],
+						get_class($service)
+					);
+				}
+			} catch (\Dependency_Exception $e) {
+				$errors[] = sprintf('%s: ' . $e->getMessage(), $getter[':service_key']);
+			} catch (\ReflectionException $e) {
+				// Usually an undefined class exception
+				$errors[] = sprintf('%s: ' . $e->getMessage(), $getter[':service_key']);
+			}
+		}
+
+		if ($errors) {
+			throw new \InvalidArgumentException("Your service container configuration is not valid:" . PHP_EOL . ' - ' . implode(PHP_EOL . ' - ', $errors));
+		}
+	}
+
+	/**
+	 * @param object $service
+	 * @param string $declared_type
+	 *
+	 * @return bool
+	 */
+	protected function is_expected_service_type($service, $declared_type)
+	{
+		if ($declared_type === 'mixed') {
+			return TRUE;
+		}
+
+		return ($service instanceof $declared_type);
+	}
+
+}

--- a/classes/Task/Compile/Dependencies.php
+++ b/classes/Task/Compile/Dependencies.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Compiles your service definitions into a single class with getters for each service, validating that all declared
+ * services can be created.
+ *
+ * Options:
+ *
+ *  * --class-name        - the name of the class to generate (default: Dependency_Container)
+ *  * --path              - path to output the resulting class file (default: APPPATH/classes/Dependency/Container.php)
+ *  * --config-group      - config group to load dependencies from (default: dependencies)
+ *
+ * If your service definitions are invalid, the task will fail with an error. The recommended use is to exclude the
+ * compiled class from your version control system, and compile it fresh for every build/deploy. This ensures it is
+ * up to date with all your modules and related configuration, and that your build will fail fast if the service
+ * configuration is not valid.
+ *
+ * @author    Andrew Coulton <andrew@ingenerator.com>
+ * @copyright 2014 inGenerator Ltd
+ * @licence   BSD
+ */
+class Task_Compile_Dependencies extends Minion_Task {
+
+	public function __construct()
+	{
+		$this->_options = array(
+			'class-name'   => 'Dependency_Container',
+			'path'         => APPPATH.'/classes/Dependency/Container.php',
+			'config-group' => 'dependencies'
+		);
+		parent::__construct();
+	}
+
+	/**
+	 * @param  \Validation $validation
+	 * @return \Validation
+	 */
+	public function build_validation(Validation $validation)
+	{
+		return parent::build_validation($validation)
+			->rule('class-name', 'not_empty')
+			->rule('path', 'not_empty')
+			->rule('path', array($this, '_valid_path'))
+			->rule('config-group', 'not_empty');
+	}
+
+	/**
+	 * @param array $params
+	 *
+	 * @return void
+	 */
+	protected function _execute(array $params)
+	{
+		\Minion_CLI::write('Loading dependency list from config');
+		$definitions = Dependency_Definition_List::factory()
+			->from_array(Kohana::$config->load($params['config-group'])->as_array());
+
+		\Minion_CLI::write('Compiling dependencies to '.$params['class-name'].' in '.$params['path']);
+		$compiler = new Dependency_Compiler;
+		$compiler->compile($params['class-name'], $params['path'], $definitions);
+
+		\Minion_CLI::write('Done');
+	}
+
+	/**
+	 * Check if the class can be written to the specified absolute path
+	 *
+	 * @param string $path
+	 *
+	 * @return bool
+	 */
+	public function _valid_path($path)
+	{
+		if (file_exists($path)) {
+			return is_writable($path);
+		}
+
+		$dir = dirname($path);
+		if ( ! is_dir($dir)) {
+			mkdir($dir, 0755, TRUE);
+		}
+		return is_writable($dir);
+	}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 	"require-dev": {
 		"kohana/koharness":       "dev-master",
 		"phpspec/phpspec":        "dev-master",
-		"bossa/phpspec2-expect":  "dev-master"
+		"bossa/phpspec2-expect":  "dev-master",
+		"mikey179/vfsStream":     "~1.3"
 	},
 	"extra": {
 		"branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
 		"kohana/core":         ">=3.3",
 		"php":                 ">=5.3.3"
 	},
+	"require-dev": {
+		"kohana/koharness":       "dev-master",
+		"phpspec/phpspec":        "dev-master",
+		"bossa/phpspec2-expect":  "dev-master"
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-0.5/develop": "0.5.x-dev",

--- a/koharness.php
+++ b/koharness.php
@@ -1,0 +1,7 @@
+<?php
+// Configuration for running module tests with koharness
+return array(
+    'modules' => array(
+        'kohana-dependencies' => __DIR__
+    )
+);

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,5 @@
+formatter.name: pretty
+suites:
+  main:
+    src_path:  classes
+    namespace:

--- a/spec/Dependency/CompilerSpec.php
+++ b/spec/Dependency/CompilerSpec.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * @author    Andrew Coulton <andrew@ingenerator.com>
+ * @copyright 2014 inGenerator Ltd
+ * @licence   BSD
+ */
+namespace spec;
+use org\bovigo\vfs\vfsStream;
+use PhpSpec\Exception\Example\FailureException;
+use PhpSpec\ObjectBehavior;
+
+require_once __DIR__.'/../../koharness_bootstrap.php';
+
+/**
+ *
+ * @see \Dependency_Compiler
+ */
+class Dependency_CompilerSpec extends ObjectBehavior
+{
+	/**
+	 * $this->subject is an alias of $this, but allows for proper type hinting of the subject class.
+	 *
+	 * @var \Dependency_Compiler
+	 */
+	protected $subject;
+
+	public function __construct()
+	{
+		$this->subject = $this;
+	}
+
+	function let()
+	{
+		vfsStream::setup('compiled');
+	}
+
+	function it_is_initializable()
+	{
+		$this->subject->shouldHaveType('\Dependency_Compiler');
+	}
+
+	function it_creates_file_at_requested_path()
+	{
+		$file = $this->given_compiled_to_temp_file(uniqid('services'), new \Dependency_Definition_List);
+		expect(file_exists($file))->toBe(TRUE);
+	}
+
+	function it_compiles_class_definition_for_requested_class_name()
+	{
+		$this->given_compiled_to_unique_class(new \Dependency_Definition_List);
+	}
+
+	function its_compiled_class_is_an_instantiable_dependency_container()
+	{
+		$dependencies = new \Dependency_Definition_List;
+		$class = $this->given_compiled_to_unique_class(new \Dependency_Definition_List);
+		expect(new $class($dependencies))->toBeAnInstanceOf($class);
+		expect(new $class($dependencies))->toBeAnInstanceOf('\Dependency_Container');
+	}
+
+	function it_adds_getter_for_each_defined_service()
+	{
+		$class = $this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+				->from_array(array(
+					'date' => array('_settings' => array('class' => '\DateTime')),
+					'array' => array('_settings' => array('class' => '\ArrayObject')),
+				))
+		);
+
+		expect(method_exists($class, 'get_date'))->toBe(TRUE);
+		expect(method_exists($class, 'get_array'))->toBe(TRUE);
+	}
+
+	function it_adds_getter_with_underscores_for_nested_services()
+	{
+		$class = $this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+				->from_array(array(
+					'date' => array(
+						'time' => array('_settings' => array('class' => '\DateTime'))
+					),
+				))
+		);
+
+		expect(method_exists($class, 'get_date_time'))->toBe(TRUE);
+	}
+
+	function its_generated_service_container_can_create_services()
+	{
+		$definitions = \Dependency_Definition_List::factory()
+			->from_array(array('date' => array('_settings' => array('class' => '\DateTime'))));
+
+		$class = $this->given_compiled_to_unique_class($definitions);
+		$container = new $class($definitions);
+		expect($container->get_date())->toBeAnInstanceOf('\DateTime');
+	}
+
+	function it_declares_correct_getter_phpdoc_return_type_with_for_simple_service()
+	{
+		$class = $this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+				->from_array(array('date' => array('_settings' => array('class' => '\DateTime'))))
+		);
+		expect($class)->toDeclareMethodReturnType('get_date', '\DateTime');
+	}
+
+	function it_declares_correct_getter_phpdoc_return_type_for_service_provided_by_static_factory_with_phpdoc()
+	{
+		$class = $this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+			->from_array(array(
+				'array' => array(
+					'_settings' => array(
+						'class' => __NAMESPACE__ . '\DocumentedArrayObjectFactory',
+						'constructor' => 'factory'
+					)
+				)
+			)));
+
+		expect($class)->toDeclareMethodReturnType('get_array', '\ArrayObject');
+	}
+
+	function it_declares_mixed_return_type_for_service_provided_by_static_factory_with_no_phpdoc()
+	{
+		$class = $this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+			->from_array(array(
+				'array' => array(
+					'_settings' => array(
+						'class' => __NAMESPACE__ . '\UndocumentedFactory',
+						'constructor' => 'factory'
+					)
+				)
+			)));
+
+		expect($class)->toDeclareMethodReturnType('get_array', 'mixed');
+	}
+
+	function it_alpha_sorts_getters()
+	{
+		$file = $this->given_compiled_to_temp_file(uniqid('services'), \Dependency_Definition_List::factory()
+				->from_array(array(
+					'date' => array('_settings' => array('class' => '\DateTime')),
+					'array' => array('_settings' => array('class' => '\ArrayObject')),
+				))
+		);
+
+		expect(file_get_contents($file))->toMatch('/get_array.+?get_date/s');
+	}
+
+	function it_throws_if_service_returns_unexpected_type()
+	{
+		try {
+			$this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+				->from_array(array(
+					'date' => array(
+						'_settings' => array(
+							'class' => __NAMESPACE__ . '\BadlyDocumentedFactory',
+							'constructor' => 'factory'
+						)
+					)
+				)));
+			throw new FailureException("Expected exception, none thrown");
+		} catch (\InvalidArgumentException $e) {
+			expect($e->getMessage())->toMatch('/date/');
+		}
+	}
+
+	function it_throws_if_service_refers_to_undefined_class()
+	{
+		try {
+			$this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+				->from_array(array(
+					'undefined' => array('_settings' => array('class' => __NAMESPACE__ . '\\UndefinedClass'))
+				)));
+			throw new FailureException("Expected exception, none thrown");
+		} catch (\InvalidArgumentException $e) {
+			expect($e->getMessage())->toMatch('/undefined/');
+		}
+	}
+
+	function it_throws_if_service_dependencies_cannot_be_met_from_the_container()
+	{
+		try {
+			$this->given_compiled_to_unique_class(\Dependency_Definition_List::factory()
+				->from_array(array(
+					'invalid' => array('_settings' => array('class' => '\DateTime', 'arguments' => array('%undefined%')))
+				)));
+			throw new FailureException("Expected exception, none thrown");
+		} catch (\InvalidArgumentException $e) {
+			expect($e->getMessage())->toMatch('/invalid/');
+		}
+	}
+
+	/**
+	 * @param string $class
+	 * @param \Dependency_Definition_List $definitions
+	 * @return string the filename
+	 */
+	function given_compiled_to_temp_file($class, \Dependency_Definition_List $definitions)
+	{
+		$file = vfsStream::url('compiled/'.$class.'.php');
+		$this->subject->compile($class, $file, $definitions);
+		return $file;
+	}
+
+	/**
+	 * @param \Dependency_Definition_List $definitions
+	 *
+	 * @return object
+	 */
+	protected function given_compiled_to_unique_class(\Dependency_Definition_List $definitions)
+	{
+		$class = uniqid('services');
+		expect($class)->notToBeDefinedClassName();
+		$this->given_compiled_to_temp_file($class, $definitions);
+		expect($class)->toBeDefinedClassName();
+		return $class;
+	}
+
+	public function getMatchers()
+	{
+		$matchers = parent::getMatchers();
+
+		$matchers['beDefinedClassName'] = function ($name) {
+			return class_exists($name, FALSE);
+		};
+
+		$matchers['declareMethodReturnType'] = function ($class, $method_name, $expect_type) {
+			$reflection = new \ReflectionClass($class);
+			$method     = $reflection->getMethod($method_name);
+			$comment    = $method->getDocComment();
+
+			if ( ! preg_match('/^\s+\* @return (.+?)$/m', $comment, $matches)) {
+				throw new FailureException("Expected $method_name doc comment to define @return tag but it does not: " . $comment);
+			}
+			if ($expect_type !== $matches[1]) {
+				var_dump($matches[1]);
+				throw new FailureException("Expected $method_name @return of " . $expect_type . ", got " . $matches[1]);
+			}
+			return TRUE;
+		};
+		return $matchers;
+	}
+
+}
+
+class DocumentedArrayObjectFactory {
+	/**
+	 * @return \ArrayObject
+	 */
+	public static function factory()
+	{
+		return new \ArrayObject;
+	}
+}
+
+class UndocumentedFactory {
+
+	public static function factory()
+	{
+		return new \ArrayObject;
+	}
+}
+
+class BadlyDocumentedFactory {
+
+	/**
+	 * @return \DateTime
+	 */
+	public static function factory()
+	{
+		return new \ArrayObject;
+	}
+}
+
+class ClassWithDependencies
+{
+	public function __construct(\DateTime $time)
+	{
+
+	}
+}

--- a/spec/Dependency/CompilerSpec.php
+++ b/spec/Dependency/CompilerSpec.php
@@ -50,7 +50,14 @@ class Dependency_CompilerSpec extends ObjectBehavior
 		$this->given_compiled_to_unique_class(new \Dependency_Definition_List);
 	}
 
-	function its_compiled_class_is_an_instantiable_dependency_container()
+    function its_compiled_class_extends_kohana_dependency_container_if_classname_conflicts()
+    {
+        $file = $this->given_compiled_to_temp_file('SomeClass', new \Dependency_Definition_List);
+        expect(file_get_contents($file))->toMatch('/class SomeClass extends \\\\Dependency_Container/');
+    }
+
+
+    function its_compiled_class_is_an_instantiable_dependency_container()
 	{
 		$dependencies = new \Dependency_Definition_List;
 		$class = $this->given_compiled_to_unique_class(new \Dependency_Definition_List);


### PR DESCRIPTION
This adds a class and minion task that can compile a Dependency_Definition_List to a custom class providing getters (with appropriate phpdoc return tags) for each defined service. This allows for IDE autocompletion and usage tracking for easier refactoring. It also creates all services as part of the compile, providing a quick way to validate that the dependency configuration is correct (or at least correct enough that it doesn't blow up with incorrect arguments or missing nested dependencies).

As the module so far has no tests, I've added a travis build configuration and phpspec (which is our preferred BDD tool at the moment) for the new class.

@Zeelot no worries if you feel this (either the compiler or the phpspec) isn't right for you, we can maintain it as a separate package if required.
